### PR TITLE
ci: use Node.js 18 for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
       - run: npm ci
       - run: npx semantic-release
         env:


### PR DESCRIPTION
The latest version of Semantic Release requires this.